### PR TITLE
Migrate chart annotations to new OCI-compliant format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Add `io.giantswarm.application.audience: all` annotation to `Chart.yaml`.
+
 ## [1.1.1] - 2025-12-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Chart: Add `io.giantswarm.application.audience: all` annotation to `Chart.yaml`.
+- Chart: Migrate team annotation from `application.giantswarm.io/team` to `io.giantswarm.application.team: tenet`.
 
 ## [1.1.1] - 2025-12-05
 

--- a/helm/gpu-operator/Chart.yaml
+++ b/helm/gpu-operator/Chart.yaml
@@ -6,8 +6,8 @@ appVersion: 25.10.1
 home: https://github.com/giantswarm/gpu-operator-app
 icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
 annotations:
-  application.giantswarm.io/team: tenet
   io.giantswarm.application.audience: all
+  io.giantswarm.application.team: tenet
 dependencies:
   - name: gpu-operator
     repository: https://helm.ngc.nvidia.com/nvidia

--- a/helm/gpu-operator/Chart.yaml
+++ b/helm/gpu-operator/Chart.yaml
@@ -7,6 +7,7 @@ home: https://github.com/giantswarm/gpu-operator-app
 icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
 annotations:
   application.giantswarm.io/team: tenet
+  io.giantswarm.application.audience: all
 dependencies:
   - name: gpu-operator
     repository: https://helm.ngc.nvidia.com/nvidia


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35733

- Add `io.giantswarm.application.audience: all` annotation
- Migrate team annotation from `application.giantswarm.io/team` to `io.giantswarm.application.team: tenet`